### PR TITLE
Update understand.ps1

### DIFF
--- a/understand.ps1
+++ b/understand.ps1
@@ -17,7 +17,7 @@ if ($args.count -gt 0){
 
     # Now perform the appropriate action if the request was understood
     if ($predictedIntent -in ("switch_on", "switch_off")){
-        if($predictedDevice -like ("*light*") -or (-like ("*fan*"))){
+        if($predictedDevice -like ("*light*") -or $predictedDevice -like ("*fan*")){
             if($predictedIntent -eq "switch_on"){
                 Write-Host("The $predictedDevice is on.")
             }


### PR DESCRIPTION
I've corrected the below line in the understand.ps1 script as I found out the below issue. 
The issue comes up when someone would like to test the Lab scenario of triggering the switch_off intent for the fan as described in the lab instructions.

**For example, using the below command:** 

`> ./understand.ps1 "Switch the fan off"`
 
**In this case, Line 20 throws the below error:**
```
-like: /home/christina/ai-900/understand.ps1:20
Line |
  20 |          if($predictedDevice -like ("*light*") -or (-like ("*fan*"))){
     |                                                     ~~~~~
     | The term '-like' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was
     | included, verify that the path is correct and try again.

```
# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-