### PR TITLE
Compatibility Issue with Win Server 2016

### DIFF
--- a/understand.ps1
+++ b/understand.ps1
@@ -1,3 +1,13 @@
+#############################
+# BEGIN COMPATIBILITY       #
+#############################
+# Brian Bagent, Arun Kumar, et al.
+# https://social.technet.microsoft.com/Forums/Windows/en-US/19b00212-52b7-4ed0-9444-15d6d461fc4f/invokerestmethod-issues
+# On older Windows Machines, you may need to uncomment the following line:
+# [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+#############################
+# END   COMPATIBILITY       #
+#############################
 $endpointUrl="YOUR_ENDPOINT"
 $key = "YOUR_KEY"
 $projectName = "YOUR_PROJECT_NAME"


### PR DESCRIPTION
The sample did not work for me on Windows Server 2016 - Version 1607 (OS Build 14393.5356) until I added the SecurityProtocol line per Brian Bagent as seen in: https://social.technet.microsoft.com/forums/Windows/en-US/19b00212-52b7-4ed0-9444-15d6d461fc4f/invokerestmethod-issues?prof=required

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-